### PR TITLE
stackrox: Add 3h timeout to ocp-4-create step

### DIFF
--- a/ci-operator/step-registry/stackrox/automation-flavors/ocp-4-e2e/stackrox-automation-flavors-ocp-4-e2e-workflow.yaml
+++ b/ci-operator/step-registry/stackrox/automation-flavors/ocp-4-e2e/stackrox-automation-flavors-ocp-4-e2e-workflow.yaml
@@ -28,6 +28,7 @@ workflow:
         requests:
           cpu: 2000m
           memory: 4000Mi
+      timeout: 3h0m0s
     test:
     - ref: stackrox-stackrox-e2e-test
     post:


### PR DESCRIPTION
## Summary

The `ocp-4-create` step in the `stackrox-automation-flavors-ocp-4-e2e` workflow had no explicit timeout, inheriting the default 2h from the Prow entrypoint. When the first OCP provisioning attempt fails (transient GCP/bootstrap flake) and the retry script starts a second attempt, 2h is not enough for two full provisioning cycles. This caused the nightly OCP 4.22 UI E2E job to be killed mid-provisioning on the retry ([build 2064515097526538240](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-stackrox-stackrox-nightlies-ocp-4-22-ui-e2e-tests/2064515097526538240)).

- Add `timeout: 3h0m0s` to the `ocp-4-create` step to fit two full provisioning cycles
- The `ocp-4-destroy` step already had an explicit `timeout: 30m0s`

/uncc
/hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)